### PR TITLE
Update graph definition to make it a static graph

### DIFF
--- a/mobilenetv3.py
+++ b/mobilenetv3.py
@@ -53,6 +53,7 @@ class h_swish(nn.Module):
 class SELayer(nn.Module):
     def __init__(self, channel, reduction=4):
         super(SELayer, self).__init__()
+        self.channel = channel
         self.avg_pool = nn.AdaptiveAvgPool2d(1)
         self.fc = nn.Sequential(
                 nn.Linear(channel, _make_divisible(channel // reduction, 8)),
@@ -62,9 +63,8 @@ class SELayer(nn.Module):
         )
 
     def forward(self, x):
-        b, c, _, _ = x.size()
-        y = self.avg_pool(x).view(b, c)
-        y = self.fc(y).view(b, c, 1, 1)
+        y = self.avg_pool(x).view(-1, self.channel)
+        y = self.fc(y).view(-1, self.channel, 1, 1)
         return x * y
 
 

--- a/mobilenetv3.py
+++ b/mobilenetv3.py
@@ -144,6 +144,7 @@ class MobileNetV3(nn.Module):
             exp_size = _make_divisible(input_channel * t, 8)
             layers.append(block(input_channel, exp_size, output_channel, k, s, use_se, use_hs))
             input_channel = output_channel
+        self.exp_size = exp_size
         self.features = nn.Sequential(*layers)
         # building last several layers
         self.conv = conv_1x1_bn(input_channel, exp_size)
@@ -163,7 +164,7 @@ class MobileNetV3(nn.Module):
         x = self.features(x)
         x = self.conv(x)
         x = self.avgpool(x)
-        x = x.view(x.size(0), -1)
+        x = x.view(-1, self.exp_size)
         x = self.classifier(x)
         return x
 


### PR DESCRIPTION
This is for better compatibility when exporting torch model to other format and when quantizing the model. The pretrained model can be loaded in the same way.